### PR TITLE
Bump MSTest.TestAdapter to 3.10.1

### DIFF
--- a/test/Hyperbee.Json.Cts/Hyperbee.Json.Cts.csproj
+++ b/test/Hyperbee.Json.Cts/Hyperbee.Json.Cts.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 

--- a/test/Hyperbee.Json.Tests/Hyperbee.Json.Tests.csproj
+++ b/test/Hyperbee.Json.Tests/Hyperbee.Json.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: MSTest.TestAdapter dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: MSTest.TestAdapter dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-minor ...
